### PR TITLE
修复课表时间判断错误的bug

### DIFF
--- a/app/src/main/java/com/jacky/lession/DailyLessonDetail.java
+++ b/app/src/main/java/com/jacky/lession/DailyLessonDetail.java
@@ -1,0 +1,43 @@
+package com.jacky.lession;
+
+import com.jacky.lession.singleLession.Lesson;
+import com.jacky.lession.singleLession.TimeRange;
+
+public class DailyLessonDetail {
+    private final LessonDetail[] details;
+    private final WeekDay weekDay;
+    private final int week;
+
+
+    public DailyLessonDetail(Lesson[] details,WeekDay weekDay,int week) {
+        this.weekDay = weekDay;
+        this.week = week;
+        this.details = new LessonDetail[11];
+
+        for (int i = 0; i < this.details.length; i++) {
+            this.details[i]=getClass(details,i+1);
+        }
+    }
+
+    private boolean findClass(Lesson[] lessons,int lessonNum){
+        for (Lesson l :
+                lessons) {
+            if(l.hasClass(week,weekDay,lessonNum)){
+                return true;
+            }
+        }return false;
+    }
+    private LessonDetail getClass(Lesson[] lessons,int lessonNum){
+        for (Lesson l :
+                lessons) {
+            if(l.hasClass(week,weekDay,lessonNum)){
+
+                return LessonDetail.NewLessonDetail(l.getTeacher(),l.getLessonName(),l.getClass(weekDay).getLessonRoom());
+            }
+        }return LessonDetail.NoClass();
+    }
+
+    public LessonDetail getLesson(int lesson){
+        return details[lesson-1];
+    }
+}

--- a/app/src/main/java/com/jacky/lession/LessonTable.java
+++ b/app/src/main/java/com/jacky/lession/LessonTable.java
@@ -33,7 +33,8 @@ public class LessonTable {
         }
     }
 
-    public void getTargetTable(int week) {
+    public TargetTable getTargetTable(int week) {
+        return new TargetTable(week,lessons);
     }
 
     public LessonDetail getLesson(int week, int time, WeekDay weekDay) {

--- a/app/src/main/java/com/jacky/lession/LessonTable.java
+++ b/app/src/main/java/com/jacky/lession/LessonTable.java
@@ -36,7 +36,7 @@ public class LessonTable {
     public void getTargetTable(int week) {
     }
 
-    public LessonDetail getLesson(int week, int time, int weekDay) {
+    public LessonDetail getLesson(int week, int time, WeekDay weekDay) {
         if (lessons == null) {
             throw new BadLoginStatuteException("未登录！");
         } else {

--- a/app/src/main/java/com/jacky/lession/TargetTable.java
+++ b/app/src/main/java/com/jacky/lession/TargetTable.java
@@ -1,5 +1,40 @@
 package com.jacky.lession;
 
-class TargetTable {
-    
+import com.jacky.lession.singleLession.Lesson;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+
+public class TargetTable {
+    private final int week;
+    private final ArrayList<Lesson> lessons= new ArrayList<>();
+
+    TargetTable(int week, ArrayList<Lesson> lessons) {
+        this.week = week;
+
+        for (Lesson l :
+                lessons) {
+            if (l.hasClassInTargetWeek(week)) {
+                this.lessons.add(l.generateTargetWeekLesson(week));
+            }
+        }
+
+    }
+
+    public int getWeek() {
+        return week;
+    }
+
+    public DailyLessonDetail getTargetDayTable(WeekDay weekDay) {
+        LinkedList<Lesson> t = new LinkedList<>();
+        for (Lesson l :
+                lessons) {
+            if (l.hasClassInTargetDay(weekDay)) {
+                t.add(l);
+            }
+        }
+        return new DailyLessonDetail((Lesson[]) t.toArray(), weekDay, week);
+    }
+
 }

--- a/app/src/main/java/com/jacky/lession/WeekDay.java
+++ b/app/src/main/java/com/jacky/lession/WeekDay.java
@@ -1,0 +1,16 @@
+package com.jacky.lession;
+
+public enum WeekDay {
+    Monday(1),Tuesday(2),Wednesday(3),Thursday(4),Friday(5),Saturday(6),Sunday(7);
+
+    private final int w;
+
+    WeekDay(int w){
+
+        this.w = w;
+    }
+
+    public int getWeekDay() {
+        return w;
+    }
+}

--- a/app/src/main/java/com/jacky/lession/singleLession/Lesson.java
+++ b/app/src/main/java/com/jacky/lession/singleLession/Lesson.java
@@ -1,5 +1,7 @@
 package com.jacky.lession.singleLession;
 
+import com.jacky.lession.WeekDay;
+
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.regex.Matcher;
@@ -62,16 +64,16 @@ public class Lesson {
 
     }
 
-    public boolean hasClass(int week, int weekDay, int classTime) {
-        TimeRange t = timeRanges.get(weekDay);
+    public boolean hasClass(int week, WeekDay weekDay, int classTime) {
+        TimeRange t = timeRanges.get(weekDay.getWeekDay());
         if (t != null) {
             return t.lessonMatch(classTime, weekDay, week);
         }
         return false;
     }
 
-    public TimeRange getClass(int weekDay) {
-        return timeRanges.get(weekDay);
+    public TimeRange getClass(WeekDay weekDay) {
+        return timeRanges.get(weekDay.getWeekDay());
     }
 
 }

--- a/app/src/main/java/com/jacky/lession/singleLession/Lesson.java
+++ b/app/src/main/java/com/jacky/lession/singleLession/Lesson.java
@@ -43,6 +43,9 @@ public class Lesson {
         return teachProject;
     }
 
+    private void addTimeRange(TimeRange timeRange){
+        timeRanges.put(timeRange.getWeekDayIn(),timeRange);
+    }
     public void loadNewTimeRangeFormTeachingProject(String html) {
         int matchStatartIndex = 0;
         String usingString = html.substring(matchStatartIndex);
@@ -76,4 +79,25 @@ public class Lesson {
         return timeRanges.get(weekDay.getWeekDay());
     }
 
+    public boolean hasClassInTargetWeek(int week){
+        for (TimeRange t :
+                timeRanges.values()) {
+            if (t.hasClassInTargetWeek(week))return true;
+        }return false;
+    }
+    public Lesson generateTargetWeekLesson(int week){
+        Lesson tL=new Lesson(this.teacher,this.lessonName,this.teachProject);
+        for (TimeRange t :
+                timeRanges.values()) {
+            if (t.hasClassInTargetWeek(week)){
+                tL.addTimeRange(t);
+            }
+        }
+        return tL;
+    }
+
+    public boolean hasClassInTargetDay(WeekDay weekDay){
+        TimeRange t = timeRanges.get(weekDay.getWeekDay());
+        return t!=null;
+    }
 }

--- a/app/src/main/java/com/jacky/lession/singleLession/TimeRange.java
+++ b/app/src/main/java/com/jacky/lession/singleLession/TimeRange.java
@@ -23,12 +23,29 @@ public class TimeRange {
     }
 
     boolean lessonMatch(int lessonNumber, WeekDay weekDay, int week) {
-        return lessonNumber >= start && lessonNumber <= end && weekDay.getWeekDay() == weekDayIn && week >= weekStart
+        return hasClassInTargetLessonTime(lessonNumber) &&
+                hasClassInTargetDay(weekDay) &&
+                hasClassInTargetWeek(week);
+    }
+
+    boolean hasClassInTargetWeek(int week) {
+        return week >= weekStart
                 && week <= weekEnd;
+    }
+
+    boolean hasClassInTargetDay(WeekDay weekDay) {
+        return weekDay.getWeekDay() == weekDayIn;
+    }
+    boolean hasClassInTargetLessonTime(int lessonNum){
+        return lessonNum >= start && lessonNum <= end;
     }
 
     public String getLessonRoom() {
         return roomName;
+    }
+
+    int getWeekDayIn() {
+        return weekDayIn;
     }
 
 }

--- a/app/src/main/java/com/jacky/lession/singleLession/TimeRange.java
+++ b/app/src/main/java/com/jacky/lession/singleLession/TimeRange.java
@@ -1,5 +1,7 @@
 package com.jacky.lession.singleLession;
 
+import com.jacky.lession.WeekDay;
+
 public class TimeRange {
     private final int start;
     private final int end;
@@ -20,9 +22,9 @@ public class TimeRange {
         this.roomName = roomName;
     }
 
-    boolean lessonMatch(int lessonNumber, int weekDay, int week) {
-        return lessonNumber >= start && lessonNumber <= end && weekDay == weekDayIn && week <= weekStart
-                && week >= weekEnd;
+    boolean lessonMatch(int lessonNumber, WeekDay weekDay, int week) {
+        return lessonNumber >= start && lessonNumber <= end && weekDay.getWeekDay() == weekDayIn && week >= weekStart
+                && week <= weekEnd;
     }
 
     public String getLessonRoom() {


### PR DESCRIPTION
修复课表时间判断错误的bug
添加```getTargetTable()```方法，用于获取特定周的课表